### PR TITLE
Add single-file walk/work log app (index.html)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,323 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>柴犬がちくわを食べるゲーム</title>
-  <link rel="stylesheet" href="style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>散歩・作業ログ</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f5f6f8;
+      --card: #ffffff;
+      --text: #1f2933;
+      --muted: #6b7280;
+      --accent: #2563eb;
+      --danger: #dc2626;
+      --border: #e5e7eb;
+      --shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 24px 16px 40px;
+    }
+    header {
+      margin-bottom: 20px;
+    }
+    h1 {
+      font-size: 1.6rem;
+      margin: 0 0 6px;
+    }
+    p.subtitle {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+    .card {
+      background: var(--card);
+      border-radius: 16px;
+      padding: 18px;
+      box-shadow: var(--shadow);
+      border: 1px solid var(--border);
+    }
+    .form-grid {
+      display: grid;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: 6px;
+      font-size: 0.9rem;
+    }
+    input, textarea {
+      width: 100%;
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      font-size: 1rem;
+      background: #fff;
+    }
+    textarea {
+      min-height: 90px;
+      resize: vertical;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      justify-content: space-between;
+    }
+    button {
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      padding: 10px 18px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      background: var(--accent);
+      color: #fff;
+      min-width: 140px;
+    }
+    button.secondary {
+      background: #fff;
+      color: var(--accent);
+      border: 1px solid var(--accent);
+    }
+    button.danger {
+      background: #fff;
+      color: var(--danger);
+      border: 1px solid var(--danger);
+    }
+    .list {
+      margin-top: 18px;
+      display: grid;
+      gap: 12px;
+    }
+    .entry {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 12px 14px;
+      background: #fff;
+      display: grid;
+      gap: 6px;
+    }
+    .entry-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      font-weight: 600;
+    }
+    .entry-meta {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+    .entry-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 6px;
+    }
+    .entry-actions button {
+      min-width: auto;
+      padding: 6px 14px;
+      font-size: 0.85rem;
+    }
+    .empty {
+      text-align: center;
+      color: var(--muted);
+      padding: 20px 0;
+    }
+    .footer-note {
+      margin-top: 10px;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+    @media (max-width: 540px) {
+      button {
+        width: 100%;
+      }
+      .actions {
+        flex-direction: column;
+      }
+    }
+  </style>
 </head>
 <body>
-  <div id="game">
-    <div id="score">Score: 0</div>
-    <div id="dog">🐕</div>
-    <button id="chikuwa">ちくわをあげる</button>
-  </div>
-  <script src="script.js"></script>
+  <main>
+    <header>
+      <h1>散歩・作業ログ</h1>
+      <p class="subtitle">今日の散歩や作業をサクッと記録。ローカルに保存されます。</p>
+    </header>
+
+    <section class="card" aria-label="ログ入力">
+      <div class="form-grid">
+        <div>
+          <label for="date">日付</label>
+          <input id="date" type="date" required>
+        </div>
+        <div>
+          <label for="duration">所要時間（分）</label>
+          <input id="duration" type="number" min="1" placeholder="例: 30" required>
+        </div>
+        <div>
+          <label for="memo">メモ</label>
+          <textarea id="memo" placeholder="散歩ルートや気づきなど"></textarea>
+        </div>
+      </div>
+      <div class="actions">
+        <button id="add">追加する</button>
+        <button id="export" class="secondary">CSVエクスポート</button>
+      </div>
+      <p class="footer-note">※ ブラウザのlocalStorageに保存されます。</p>
+    </section>
+
+    <section aria-label="ログ一覧">
+      <div class="list" id="list"></div>
+    </section>
+  </main>
+
+  <script>
+    const STORAGE_KEY = "walkLogs";
+    const dateInput = document.getElementById("date");
+    const durationInput = document.getElementById("duration");
+    const memoInput = document.getElementById("memo");
+    const listEl = document.getElementById("list");
+
+    const todayIso = new Date().toISOString().slice(0, 10);
+    dateInput.value = todayIso;
+
+    const loadLogs = () => {
+      try {
+        const data = localStorage.getItem(STORAGE_KEY);
+        return data ? JSON.parse(data) : [];
+      } catch (error) {
+        console.warn("保存データの読み込みに失敗しました", error);
+        return [];
+      }
+    };
+
+    const saveLogs = (logs) => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(logs));
+    };
+
+    const renderLogs = () => {
+      const logs = loadLogs();
+      listEl.innerHTML = "";
+      if (logs.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "empty";
+        empty.textContent = "まだログがありません。";
+        listEl.appendChild(empty);
+        return;
+      }
+
+      logs
+        .sort((a, b) => b.createdAt - a.createdAt)
+        .forEach((log) => {
+          const entry = document.createElement("div");
+          entry.className = "entry";
+
+          const header = document.createElement("div");
+          header.className = "entry-header";
+          header.textContent = `${log.date} ・ ${log.duration}分`;
+
+          const memo = document.createElement("div");
+          memo.textContent = log.memo || "(メモなし)";
+
+          const meta = document.createElement("div");
+          meta.className = "entry-meta";
+          meta.textContent = `記録日時: ${new Date(log.createdAt).toLocaleString()}`;
+
+          const actions = document.createElement("div");
+          actions.className = "entry-actions";
+
+          const deleteBtn = document.createElement("button");
+          deleteBtn.className = "danger";
+          deleteBtn.textContent = "削除";
+          deleteBtn.addEventListener("click", () => {
+            const updated = loadLogs().filter((item) => item.id !== log.id);
+            saveLogs(updated);
+            renderLogs();
+          });
+
+          actions.appendChild(deleteBtn);
+          entry.appendChild(header);
+          entry.appendChild(memo);
+          entry.appendChild(meta);
+          entry.appendChild(actions);
+          listEl.appendChild(entry);
+        });
+    };
+
+    document.getElementById("add").addEventListener("click", () => {
+      const date = dateInput.value || todayIso;
+      const duration = Number(durationInput.value);
+      const memo = memoInput.value.trim();
+
+      if (!date || !duration || duration <= 0) {
+        alert("日付と所要時間を入力してください。");
+        return;
+      }
+
+      const logs = loadLogs();
+      const newLog = {
+        id: crypto.randomUUID(),
+        date,
+        duration,
+        memo,
+        createdAt: Date.now(),
+      };
+
+      logs.push(newLog);
+      saveLogs(logs);
+      durationInput.value = "";
+      memoInput.value = "";
+      dateInput.value = todayIso;
+      renderLogs();
+    });
+
+    document.getElementById("export").addEventListener("click", () => {
+      const logs = loadLogs();
+      if (logs.length === 0) {
+        alert("エクスポートするログがありません。");
+        return;
+      }
+      const header = ["日付", "所要時間(分)", "メモ", "記録日時"];
+      const rows = logs
+        .sort((a, b) => b.createdAt - a.createdAt)
+        .map((log) => [
+          log.date,
+          log.duration,
+          log.memo ? log.memo.replace(/\n/g, " ") : "",
+          new Date(log.createdAt).toLocaleString(),
+        ]);
+      const csv = [header, ...rows]
+        .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
+        .join("\n");
+
+      const blob = new Blob(["\ufeff", csv], { type: "text/csv" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `walk-log-${todayIso}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    });
+
+    renderLogs();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the previous demo page with a lightweight, single-file browser app to record short walk or work logs and keep them locally.
- Provide a no-dependency solution that works by simply opening `index.html` in a browser, including CSV export and basic mobile-friendly UI.

### Description
- Replaced the previous content with a single-file app in `index.html` that embeds HTML, CSS, and JavaScript together and adds a responsive UI for mobile.
- Implemented persistent storage using `localStorage` under the key `walkLogs`, with add and delete flows and validation for `date` and `duration` inputs.
- Added CSV export that generates a UTF-8 (BOM) CSV download of all records and includes columns `日付`, `所要時間(分)`, `メモ`, and `記録日時`.
- Uses `crypto.randomUUID()` to generate entry IDs and sorts entries by `createdAt` for display and export.

### Testing
- Attempted automated rendering capture with `Playwright` after starting a static server via `python -m http.server`, but the Playwright browser process crashed (SIGSEGV) and the screenshot run failed.
- No automated tests completed successfully; the change is a static HTML/JS update and should be validated by opening `index.html` in a browser and exercising add → list → reload persistence → CSV export flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989233549b48326972fca0130727c68)